### PR TITLE
Moved the Disclaimer of Warranties to the Citation Page

### DIFF
--- a/citation-page/index.html
+++ b/citation-page/index.html
@@ -60,7 +60,21 @@
                     </div>
                 </div>
             </div>
+            <div class="accordion-item">
+                <div class="accordion-header" data-title="Data Disclaimer">+ Disclaimer of Warranties</div>
+                <div class="accordion-content">
+                    <p>
+                        Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to you (the "user").
+                    </p>
+                    <p>
+                        To the extent possible, in no event will the Licensor be liable to any user on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to the user.
+                    </p>
+                    <p>
+                        The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+                    </p>
+                </div>
             </div>
         </div>
+    </div>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -41,28 +41,9 @@
         </p>
 
         <p>Here is the link to the American "Local Government Elections Database" that was used for our analysis in this project!</p>
-        <a href="https://osf.io/mv5e6/">Visit Local Government Elections Database website</a>
-
-        <p></p>
-      
+        <a href="https://osf.io/mv5e6/">Visit Local Government Elections Database website</a>      
       <h2>US Map (Demo)</h2>
     <div id="map"></div>
     <script type="module" src="us_map_test.js"></script>
-
-    <div class="accordion-container">
-        <div class="accordion">
-            <div class="accordion-item">
-                <div class="accordion-header" data-title="Data Disclaimer">+ Data Disclaimer</div>
-                <div class="accordion-content">
-                    <p>Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
-
-                To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
-
-                The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.</p>
-                 </div>
-            </div>
-        </div>
-    </div>
-         <script src="accordion_script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Hi Team,

I moved the disclaimer of warranties from the home page to the citation page. I'm pushing this to the citation branch so we can merge all the citation changes at once, but I hope that this will complete the second-to-last task in the citation story.

As always, let me know if you have questions!

Best wishes,

Brandon